### PR TITLE
Disable Wayland

### DIFF
--- a/io.github.stella_emu.Stella.yaml
+++ b/io.github.stella_emu.Stella.yaml
@@ -12,8 +12,7 @@ cleanup:
 
 finish-args:
   - --filesystem=home
-  - --socket=fallback-x11
-  - --socket=wayland
+  - --socket=x11
   - --socket=pulseaudio
   - --device=all
 


### PR DESCRIPTION
With Wayland on KDE I can't open the input options after exiting a game. With Xwayland it works fine.